### PR TITLE
Small buildsys improvement

### DIFF
--- a/liblabjackusb/Makefile
+++ b/liblabjackusb/Makefile
@@ -6,9 +6,10 @@
 UNAME = $(shell uname -s)
 
 VERSION = 2.5.3
-DESTINATION = /usr/local/lib
+PREFIX ?= /usr/local
+DESTINATION = $(PREFIX)/lib
 HEADER = labjackusb.h
-HEADER_DESTINATION = /usr/local/include
+HEADER_DESTINATION = $(PREFIX)/include
 LIBFLAGS = -lusb-1.0 -lc
 ADD_LDCONFIG_PATH = ./add_ldconfig_path.sh
 
@@ -22,12 +23,14 @@ ifeq ($(UNAME),Darwin)
 	# Build for multiple architectures
 	#ARCHFLAGS = -arch i386 -arch x86_64 -arch ppc
 	COMPILE = libtool -dynamic -o $(TARGET) -install_name $(TARGET) -current_version $(VERSION) -compatibility_version $(VERSION) labjackusb.o $(LIBFLAGS)
+	RUN_LDCONFIG ?= 0
 else
 	#Linux operating system macros
 	TARGET = liblabjackusb.so.$(VERSION)
 	# Build for only the host architecture
 	ARCHFLAGS =
 	COMPILE = $(CC) -shared -Wl,-soname,liblabjackusb.so -o $(TARGET) labjackusb.o $(LIBFLAGS)
+	RUN_LDCONFIG ?= 1
 endif
 
 CFLAGS += -fPIC -g -Wall $(ARCHFLAGS)
@@ -45,7 +48,7 @@ install: $(TARGET)
 	install $(TARGET) $(DESTINATION)
 	test -z $(HEADER_DESTINATION) || mkdir -p $(HEADER_DESTINATION)
 	install $(HEADER) $(HEADER_DESTINATION)
-ifeq ($(UNAME),Linux)
+ifeq ($(RUN_LDCONFIG),1)
 	@$(ADD_LDCONFIG_PATH)
 	ldconfig
 endif


### PR DESCRIPTION
- Allow overriding the install prefix with the PREFIX variable (defaults
  to /usr/local).
- Allow to _not_ run ldconfig, even on Linux, if RUN_LDCONFIG=0.

With these changes, it is possible to build and install on NixOS,
without patching.

NOTE: I'm not touching the ./install.sh script, because it is
fundamentally incompatible with NixOS. (On NixOS, packages can be
installed by ordinary users, but system-wide changes like adding udev
rules or modifying user group membership must be handled in the
system-wide configuration that only root can change.)
