### PR TITLE
Made LJUSB_Write and LJUSB_WriteTO buffer parameters const

### DIFF
--- a/liblabjackusb/labjackusb.c
+++ b/liblabjackusb/labjackusb.c
@@ -746,7 +746,7 @@ static unsigned long LJUSB_DoTransfer(HANDLE hDevice, unsigned char endpoint, BY
     }
 
     if (r == LIBUSB_ERROR_TIMEOUT) {
-        //Timeout occured but may have received partial data.  Setting errno but
+        //Timeout occurred but may have received partial data.  Setting errno but
         //returning the number of bytes transferred which may be > 0.
 #if LJ_DEBUG
         fprintf(stderr, "LJUSB_DoTransfer: Transfer timed out. Returning.\n");
@@ -943,12 +943,12 @@ unsigned long LJUSB_BulkWrite(HANDLE hDevice, unsigned char endpoint, BYTE *pBuf
 }
 
 
-unsigned long LJUSB_Write(HANDLE hDevice, BYTE *pBuff, unsigned long count)
+unsigned long LJUSB_Write(HANDLE hDevice, const BYTE *pBuff, unsigned long count)
 {
 #if LJ_DEBUG
     fprintf(stderr, "LJUSB_Write: calling LJUSB_Write.\n");
 #endif
-    return LJUSB_SetupTransfer(hDevice, pBuff, count, LJ_LIBUSB_TIMEOUT_DEFAULT, LJUSB_WRITE);
+    return LJUSB_SetupTransfer(hDevice, (BYTE *)pBuff, count, LJ_LIBUSB_TIMEOUT_DEFAULT, LJUSB_WRITE);
 }
 
 
@@ -970,12 +970,12 @@ unsigned long LJUSB_Stream(HANDLE hDevice, BYTE *pBuff, unsigned long count)
 }
 
 
-unsigned long LJUSB_WriteTO(HANDLE hDevice, BYTE *pBuff, unsigned long count, unsigned int timeout)
+unsigned long LJUSB_WriteTO(HANDLE hDevice, const BYTE *pBuff, unsigned long count, unsigned int timeout)
 {
 #if LJ_DEBUG
     fprintf(stderr, "LJUSB_Stream: calling LJUSB_WriteTO.\n");
 #endif
-    return LJUSB_SetupTransfer(hDevice, pBuff, count, timeout, LJUSB_WRITE);
+    return LJUSB_SetupTransfer(hDevice, (BYTE *)pBuff, count, timeout, LJUSB_WRITE);
 }
 
 

--- a/liblabjackusb/labjackusb.h
+++ b/liblabjackusb/labjackusb.h
@@ -193,7 +193,7 @@ bool LJUSB_ResetConnection(HANDLE hDevice);
 // and you should re-open the device.
 // hDevice = The handle for your device
 
-unsigned long LJUSB_Write(HANDLE hDevice, BYTE *pBuff, unsigned long count);
+unsigned long LJUSB_Write(HANDLE hDevice, const BYTE *pBuff, unsigned long count);
 // Writes to a device with a 1 second timeout.  If the timeout time elapses and
 // no data is transferred the USB request is aborted and the call returns.
 // Returns the number of bytes written, or 0 on error and errno is set.
@@ -224,7 +224,7 @@ unsigned long LJUSB_Stream(HANDLE hDevice, BYTE *pBuff, unsigned long count);
 // This function replaces the deprecated LJUSB_BulkRead, which required the
 // (stream) endpoint.
 
-unsigned long LJUSB_WriteTO(HANDLE hDevice, BYTE *pBuff, unsigned long count, unsigned int timeout);
+unsigned long LJUSB_WriteTO(HANDLE hDevice, const BYTE *pBuff, unsigned long count, unsigned int timeout);
 // Writes to a device with a specified timeout.  If the timeout time elapses and
 // no data is transferred the USB request is aborted and the call returns.
 // Returns the number of bytes written, or 0 on error and errno is set.


### PR DESCRIPTION
This makes things nicer for users of the API but requires
an distasteful casting away of the const in the implemenatation.
A good compromise I think.

Also fixed a small spelling mistake.