### PR TITLE
Fixing `install` target when non-default `PREFIX`.

### DIFF
--- a/liblabjackusb/Makefile
+++ b/liblabjackusb/Makefile
@@ -55,7 +55,7 @@ install: $(TARGET)
 	test -z $(HEADER_DESTINATION) || mkdir -p $(HEADER_DESTINATION)
 	install $(HEADER) $(HEADER_DESTINATION)
 ifeq ($(RUN_LDCONFIG),1)
-	@$(ADD_LDCONFIG_PATH)
+	@$(ADD_LDCONFIG_PATH) $(DESTINATION)
 	ldconfig
 endif
 

--- a/liblabjackusb/add_ldconfig_path.sh
+++ b/liblabjackusb/add_ldconfig_path.sh
@@ -1,18 +1,31 @@
 #! /bin/bash
+#
+# add_ldconfig_path.sh
+#
+# Idempotently add a path to /etc/ld.so.conf
+
+set -e
+set -u
 
 ldconfig_file=/etc/ld.so.conf
-path=/usr/local/lib
-TRUE=0
-path_exists=1
+if [ $# -eq 0 ]; then
+    path=/usr/local/lib
+elif [ $# -eq 1 ]; then
+    path=$1
+else
+    echo "$0 error - Invalid number of arguments"
+    echo "Usage: $0 [LIB_DIRECTORY_PATH]"
+    exit 1
+fi
 
 for line in `cat $ldconfig_file`; do
-	if [ $line == $path ]; then
-		path_exists=$TRUE
-	fi
+    if [ $line == $path ]; then
+        # The path has already been added to the config file,
+        # so there is nothing left to do.
+        exit 0
+    fi
 done
 
-if [ $path_exists -ne $TRUE ]; then
-	echo "$path  >> $ldconfig_file"
-	echo $path  >> $ldconfig_file
-fi
+echo "echo \"$path\" >> $ldconfig_file"
+echo "$path" >> $ldconfig_file
 


### PR DESCRIPTION
I believe this addresses the primary concern behind #16, but also adds the custom (PREFIX'd) path to /etc/ld.so.conf.

There's some unrelated clean-up in this commit, so let me know if you want the minimal changes, @davelopez01.