### PR TITLE
Fix OSX "relative path not allowed" issue

### DIFF
--- a/liblabjackusb/Makefile
+++ b/liblabjackusb/Makefile
@@ -12,11 +12,11 @@ HEADER = labjackusb.h
 HEADER_DESTINATION = $(PREFIX)/include
 LIBFLAGS = -lusb-1.0 -lc
 ADD_LDCONFIG_PATH = ./add_ldconfig_path.sh
-LINK_SO ?= 0
 
 ifeq ($(UNAME),Darwin)
 	#Mac OS X operating system macros
-	TARGET = liblabjackusb-$(VERSION).dylib
+	ext = dylib
+	TARGET = liblabjackusb-$(VERSION).$(ext)
 
 	# Build for only the host architecture
 	#ARCHFLAGS =
@@ -28,16 +28,27 @@ ifeq ($(UNAME),Darwin)
 	#ARCHFLAGS = -arch i386 -arch x86_64 -arch ppc
 
 	COMPILE = libtool -dynamic -o $(TARGET) -install_name $(TARGET) -current_version $(VERSION) -compatibility_version $(VERSION) labjackusb.o $(LIBFLAGS)
+
+	# By default, create link from
+	# liblabjackusb.dylib to liblabjackusb-$(VERSION).dylib
+	# because ldconfig will not be run on Mac
 	RUN_LDCONFIG ?= 0
+	LINK_SO ?= 1
 else
 	#Linux operating system macros
-	TARGET = liblabjackusb.so.$(VERSION)
+	ext = so
+	TARGET = liblabjackusb.$(ext).$(VERSION)
 
 	# Build for only the host architecture
 	#ARCHFLAGS =
 
-	COMPILE = $(CC) -shared -Wl,-soname,liblabjackusb.so -o $(TARGET) labjackusb.o $(LIBFLAGS)
+	COMPILE = $(CC) -shared -Wl,-soname,liblabjackusb.$(ext) -o $(TARGET) labjackusb.o $(LIBFLAGS)
+
+	# By default, do not create link from
+	# liblabjackusb.dylib to liblabjackusb-$(VERSION).dylib
+	# because ldconfig will be run on Linux
 	RUN_LDCONFIG ?= 1
+	LINK_SO ?= 0
 endif
 
 CFLAGS += -fPIC -g -Wall $(ARCHFLAGS)
@@ -60,7 +71,7 @@ ifeq ($(RUN_LDCONFIG),1)
 	ldconfig
 endif
 ifeq ($(LINK_SO),1)
-	ln -i -s $(TARGET) $(DESTINATION)/liblabjackusb.so
+	ln -i -s $(DESTINATION)/$(TARGET) $(DESTINATION)/liblabjackusb.$(ext)
 endif
 
 clean:

--- a/liblabjackusb/Makefile
+++ b/liblabjackusb/Makefile
@@ -16,7 +16,7 @@ LINK_SO ?= 0
 
 ifeq ($(UNAME),Darwin)
 	#Mac OS X operating system macros
-	TARGET = liblabjackusb.dylib
+	TARGET = liblabjackusb-$(VERSION).dylib
 
 	# Build for only the host architecture
 	#ARCHFLAGS =


### PR DESCRIPTION
On OSX, this PR:
- creates a TARGET of liblabjackusb-VERSION.dylib instead of liblabjackusb.dylib
- enables LINK_SO to create a liblabjackusb.dylib link during `make install`