### PR TITLE
Resolve compiler warnings

### DIFF
--- a/examples/U6/u6.c
+++ b/examples/U6/u6.c
@@ -711,7 +711,7 @@ long eAIN(HANDLE Handle, u6CalibrationInfo *CalibrationInfo, long ChannelP, long
         return -1;
     }
 
-    if( Settling < 0 && Settling > 4 )
+    if( Settling < 0 || Settling > 4 )
     {
         printf("eAIN error: Invalid Settling value\n");
         return -1;

--- a/examples/U6/u6.h
+++ b/examples/U6/u6.h
@@ -129,7 +129,7 @@ HANDLE openUSBConnection( int localID);
 void closeUSBConnection( HANDLE hDevice);
 //Closes a HANDLE to a U6 device.
 
-long getTickCount();
+long getTickCount( void);
 //Returns the number of milliseconds that has elasped since the system was
 //started.
 


### PR DESCRIPTION
These changes resolve a few warnings seen when compiling with Xcode 12.5.1.  (I'm pretty sure the issue in `eAIN` was actually a bug.)